### PR TITLE
enhancement/cache pod files in attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-Revision history for Dist-Zilla-Plugin-MergePod
+Revision history for Dist-Zilla-Plugin-CoalescePod
 
 {{$NEXT}}
  [API CHANGES]


### PR DESCRIPTION
 Fix for issue #1 that allows Dist::Zilla::Plugin::CoalescePod to not call prune_file in the FileMunging phase

@ether pointed out this solution in the comments for Issue #1. Instead of pruning the .pod files in the FileMunging phase, prune them in the FilePruning phase and cache them in a private attribute. munge_file now examines this private attribute instead of searching through $self->zilla->files.
